### PR TITLE
Feature header

### DIFF
--- a/src/components/atoms/Icon/Icon.tsx
+++ b/src/components/atoms/Icon/Icon.tsx
@@ -4,10 +4,12 @@ export default function Icon({
     styles,
     path,
     iconAlt,
+    onClick,
 }: {
     styles: string;
     path: string;
     iconAlt: string;
+    onClick?: () => void;
 }): JSX.Element {
-    return <img className={styles} src={path} alt={iconAlt} />;
+    return <img onClick={onClick} className={styles} src={path} alt={iconAlt} />;
 }

--- a/src/components/atoms/Logo/Logo.tsx
+++ b/src/components/atoms/Logo/Logo.tsx
@@ -4,13 +4,15 @@ export default function Logo({
     source,
     alt,
     type,
+    styles,
 }: {
     source: string;
     alt: string;
     type: string;
+    styles?: string;
 }): JSX.Element {
     return (
-        <picture>
+        <picture className={styles}>
             <source srcSet={source} type={type} />
             <img src={source} alt={alt} />
         </picture>

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -4,18 +4,51 @@ import NavBar from '../../molecules/NavBar/NavBar.tsx';
 import Logo from '../../atoms/Logo/Logo.tsx';
 import Icon from '../../atoms/Icon/Icon.tsx';
 import bookmarkLogo from '../../../assets/images/logo-bookmark.svg';
+import bookmarkWhiteLogo from '../../../assets/images/logo-bookmark-white.svg';
 import burgerIcon from '../../../assets/images/icon-hamburger.svg';
 import closeIcon from '../../../assets/images/icon-close.svg';
+import { useState } from 'react';
 
 export default function Header() {
+    const [burgerOpen, setBurgerOpen] = useState(true);
+    const [menuIcon, setMenuIcon] = useState(burgerIcon);
+    const [imageAlt, setImageAlt] = useState('Burger Menu');
+    const [logo, setLogo] = useState(bookmarkLogo);
+    const [navBarStyles, setNavBarStyles] = useState('hidden');
+
+    function handleBurgerClick() {
+        setBurgerOpen(!burgerOpen);
+        setMenuIcon(burgerOpen ? closeIcon : burgerIcon);
+        setImageAlt(burgerOpen ? 'Close Menu' : 'Burger Menu');
+        setLogo(burgerOpen ? bookmarkWhiteLogo : bookmarkLogo);
+        setNavBarStyles(
+            burgerOpen
+                ? 'w-full h-full top-0 left-0 fixed flex flex-col justify-center gap-10 z-10'
+                : 'hidden',
+        );
+        console.log(burgerOpen);
+    }
+
     return (
         <header className="max-w-[1280px] mx-auto my-5 py-10 text-gray-700">
-            <div className="max-w-[1200px] w-[80%] md:w-full mx-auto flex flex-row justify-between items-center">
-                <Logo source={bookmarkLogo} alt="Bookmark" type="image/svg+xml" />
-                <Icon styles="md:hidden" path={burgerIcon} iconAlt="Burger Menu" />
-                <Icon styles="md:hidden" path={closeIcon} iconAlt="Close Menu" />
+            <div
+                className={`max-w-[1200px] w-[80%] md:w-full mx-auto flex flex-row justify-between items-center ${
+                    burgerOpen ? 'relative' : ''
+                }`}
+            >
+                <Logo styles="z-11" source={logo} alt="Bookmark" type="image/svg+xml" />
+                <Icon
+                    onClick={() => {
+                        handleBurgerClick();
+                    }}
+                    styles="md:hidden z-11"
+                    path={menuIcon}
+                    iconAlt={imageAlt}
+                />
 
-                <NavBar styles="hidden md:grid md:grid-cols-4 gap-10 justify-items-center items-center text-(--bg-gray) md:text-(--text-black) uppercase font-medium tracking-widest bg-(--color-semi-transparent-bg) md:bg-transparent">
+                <NavBar
+                    styles={`${navBarStyles} md:grid md:grid-cols-4 gap-10 justify-items-center items-center text-(--bg-gray) md:text-(--text-black) uppercase font-medium tracking-widest bg-(--color-semi-transparent-bg) md:bg-transparent`}
+                >
                     <hr className="w-[80%] md:hidden opacity-30" />
                     <Link
                         ref="#features"

--- a/src/index.css
+++ b/src/index.css
@@ -191,14 +191,29 @@
   .absolute {
     position: absolute;
   }
+  .fixed {
+    position: fixed;
+  }
   .relative {
     position: relative;
+  }
+  .top-0 {
+    top: calc(var(--spacing) * 0);
   }
   .top-\[24\%\] {
     top: 24%;
   }
   .right-\[3\%\] {
     right: 3%;
+  }
+  .left-0 {
+    left: calc(var(--spacing) * 0);
+  }
+  .z-10 {
+    z-index: 10;
+  }
+  .z-11 {
+    z-index: 11;
   }
   .order-1 {
     order: 1;
@@ -263,8 +278,8 @@
   .inline-block {
     display: inline-block;
   }
-  .table {
-    display: table;
+  .h-full {
+    height: 100%;
   }
   .w-\[70\%\] {
     width: 70%;
@@ -289,9 +304,6 @@
   }
   .max-w-\[1280px\] {
     max-width: 1280px;
-  }
-  .border-collapse {
-    border-collapse: collapse;
   }
   .rotate-180 {
     rotate: 180deg;
@@ -374,10 +386,6 @@
   .rounded-b-lg {
     border-bottom-right-radius: var(--radius-lg);
     border-bottom-left-radius: var(--radius-lg);
-  }
-  .border {
-    border-style: var(--tw-border-style);
-    border-width: 1px;
   }
   .border-2 {
     border-style: var(--tw-border-style);
@@ -523,9 +531,6 @@
   .italic {
     font-style: italic;
   }
-  .underline {
-    text-decoration-line: underline;
-  }
   .opacity-20 {
     opacity: 20%;
   }
@@ -542,10 +547,6 @@
   .shadow-lg {
     --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-  }
-  .outline {
-    outline-style: var(--tw-outline-style);
-    outline-width: 1px;
   }
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
@@ -1090,11 +1091,6 @@ a {
   inherits: false;
   initial-value: 0 0 #0000;
 }
-@property --tw-outline-style {
-  syntax: "*";
-  inherits: false;
-  initial-value: solid;
-}
 @property --tw-blur {
   syntax: "*";
   inherits: false;
@@ -1179,7 +1175,6 @@ a {
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
-      --tw-outline-style: solid;
       --tw-blur: initial;
       --tw-brightness: initial;
       --tw-contrast: initial;


### PR DESCRIPTION
This pull request introduces enhancements to the `Header` component's functionality and styling, along with updates to the `Icon` and `Logo` components to support additional props. It also includes several modifications to the `index.css` file to add new utility classes and remove unused ones.

### Component Enhancements:

* **`Icon` Component**: Added an optional `onClick` prop to enable click event handling and updated the `img` element to use this prop. (`src/components/atoms/Icon/Icon.tsx`, [src/components/atoms/Icon/Icon.tsxR7-R14](diffhunk://#diff-9002dd64ae4cc5629a59d7e976e0d30607102ac860d1070b236da8d7a3520e10R7-R14))
* **`Logo` Component**: Added an optional `styles` prop to allow custom class names for styling the `picture` element. (`src/components/atoms/Logo/Logo.tsx`, [src/components/atoms/Logo/Logo.tsxR7-R15](diffhunk://#diff-c6bdbeb47e77db500d539e3c1d609dcadc359efe805c0c5b5c4104274a2d8361R7-R15))
* **`Header` Component**: Introduced a responsive burger menu with state management for toggling the menu's visibility and updating icons, logo, and styles dynamically. (`src/components/organisms/Header/Header.tsx`, [src/components/organisms/Header/Header.tsxR7-R51](diffhunk://#diff-13d440ffb7bea2e4a4ef8495c134721fb23aac9d0d938018adc6ef87e970d8c3R7-R51))

### CSS Updates:

* **New Utility Classes**: Added utility classes for `fixed`, `top-0`, `left-0`, `z-10`, `z-11`, and `h-full` to support the new burger menu functionality. (`src/index.css`, [[1]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eR194-R217) [[2]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL266-R282)
* **Removed Unused Classes**: Removed several unused utility classes such as `table`, `border-collapse`, `border`, `underline`, and `outline` to clean up the CSS file. (`src/index.css`, [[1]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL293-L295) [[2]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL378-L381) [[3]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL526-L528) [[4]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL546-L549) [[5]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL1093-L1097) [[6]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL1182)